### PR TITLE
Fix timestamps in be-livre debate

### DIFF
--- a/public/debates/transcriptions/be-vs-livre.json
+++ b/public/debates/transcriptions/be-vs-livre.json
@@ -86,7 +86,7 @@
     },
     {
         "speaker": "Mariana Mortágua",
-        "text": "Imaginemos a crueldade de dizer a um idoso com 70 que só está protegido até aos 75, ou que aos 75 só está protegido até aos 80.",
+        "text": "Portanto, imaginemos a crueldade de dizer a um idoso com 70 que só está protegido até aos 75, ou que aos 75 só está protegido até aos 80.",
         "time": 99.179
     },
     {
@@ -116,17 +116,17 @@
     },
     {
         "speaker": "Mariana Mortágua",
-        "text": "O que eu digo e mantenho é que em 2012 foi aprovada uma lei muito cruel, porque criou regras que fizeram com que quem não fosse capaz de responder atempadamente, que não estivesse informado, e mesmo sendo capaz de responder atempadamente, tendo um regime de salvaguarda que era",
+        "text": "O que eu digo e mantenho é que em 2012 foi aprovada uma lei muito cruel, porque criou regras que fizeram com que quem não fosse capaz de responder atempadamente, que não estivesse informado, e mesmo sendo capaz de responder atempadamente, tendo um regime de salvaguarda",
         "time": 136.46
     },
     {
         "speaker": "Mariana Mortágua",
-        "text": "meramente temporário, criou um regime de insegurança e de sobressalto em todos os idosos (não só nos idosos, mas particularmente nos idosos) que a partir do momento em que recebiam uma carta de senhorio ficavam em sobressalto, sem saber o que lhes podia acontecer.",
+        "text": "que era meramente temporário, criou um regime de insegurança e de sobressalto em todos os idosos (não só nos idosos, mas particularmente nos idosos) que a partir do momento em que recebiam uma carta de senhorio ficavam em sobressalto, sem saber o que lhes podia acontecer.",
         "time": 153.067
     },
     {
         "speaker": "Mariana Mortágua",
-        "text": "E esse é um medo que foi sentido e que eu acho que foi de uma enorme crueldade.",
+        "text": "E esse é um medo que foi sentido e que eu acho que foi de uma enorme crueldade e que foi sentido por muita gente.",
         "time": 168.083
     },
     {
@@ -150,7 +150,7 @@
         "time": 204.194
     },
     {
-        "speaker": "Mariana Mortágua",
+        "speaker": "Moderadora",
         "text": "Avancemos então.",
         "time": 205.715
     },
@@ -261,7 +261,7 @@
     },
     {
         "speaker": "Moderadora",
-        "text": "Avançamos então para as vossas propostas.",
+        "text": "Avancemos então para as vossas propostas.",
         "time": 372.332
     },
     {
@@ -301,12 +301,12 @@
     },
     {
         "speaker": "Moderadora",
-        "text": "Mas tem aspectos que vos distinguem, é a minha questão.",
+        "text": "Mas têm aspectos que vos distinguem, é a minha questão.",
         "time": 434.859
     },
     {
         "speaker": "Mariana Mortágua",
-        "text": "Precisamente é aí que eu ia chegar.",
+        "text": "É precisamente aí que eu ia chegar.",
         "time": 438.602
     },
     {
@@ -411,7 +411,7 @@
     },
     {
         "speaker": "Moderadora",
-        "text": "Ou seja, nesta altura, Rui Tavares, não convém assinalar as vossas divergências porque algumas existem.",
+        "text": "Ou seja, nesta altura, Rui Tavares, não convém assinalar as vossas divergências? Porque algumas existem.",
         "time": 618.957
     },
     {
@@ -706,6 +706,11 @@
         "time": 1025.959
     },
     {
+        "speaker": "Moderadora",
+        "text": "Ao crescimento da economia.",
+        "time": 1027.000
+    }
+    {
         "speaker": "Rui Tavares",
         "text": "O crescimento da economia por si só, se não for aliado a uma melhoria da qualidade de vida, a uma sustentabilidade do nosso país e a podermos, com o dinamismo que alguns têm e a quem devemos dar asas, assegurar a dignidade de todos, é um crescimento apenas pelo crescimento.",
         "time": 1028.854
@@ -748,7 +753,7 @@
     {
         "speaker": "Moderadora",
         "text": "Mas é algo que ainda se mantém.",
-        "time": 1077.843
+        "time": 1077.343
     },
     {
         "speaker": "Moderadora",
@@ -823,7 +828,7 @@
     {
         "speaker": "Moderadora",
         "text": "Portanto, para o LIVRE em concreto, a preocupação não é tanto o crescimento em si da economia, mas é tudo o que está à volta.",
-        "time": 1158.000
+        "time": 1165.000
     },
     {
         "speaker": "Rui Tavares",
@@ -843,7 +848,7 @@
     {
         "speaker": "Moderadora",
         "text": "Vamos passar à Mariana Mortágua, soluções para pôr Portugal a crescer de forma mais sustentada.",
-        "time": 1178.005
+        "time": 1177.300
     },
     {
         "speaker": "Mariana Mortágua",
@@ -853,7 +858,7 @@
     {
         "speaker": "Moderadora",
         "text": "Normalmente é algo que é um discurso mais da direita e a direita muitas vezes acusa os partidos de esquerda de não se preocuparem com o crescimento económico do país.",
-        "time": 1189.536
+        "time": 1188.536
     },
     {
         "speaker": "Mariana Mortágua",
@@ -868,7 +873,7 @@
     {
         "speaker": "Moderadora",
         "text": "Daí que eu esteja a colocar essa questão a dois representantes da esquerda.",
-        "time": 1205.000
+        "time": 1208.000
     },
     {
         "speaker": "Mariana Mortágua",
@@ -988,7 +993,7 @@
     {
         "speaker": "Moderadora",
         "text": "Só uma pequena correção, até minha, eu há pouco disse que o ano passado, 2023, tinha sido o ano de recorde e na verdade queria ter dito 2013, fica essa a minha correção.",
-        "time": 1379.389
+        "time": 1377.389
     },
     {
         "speaker": "Mariana Mortágua",
@@ -998,7 +1003,7 @@
     {
         "speaker": "Moderadora",
         "text": "Exatamente, exatamente.",
-        "time": 1387.278
+        "time": 1387.000
     },
     {
         "speaker": "Moderadora",
@@ -1108,12 +1113,12 @@
     {
         "speaker": "Rui Tavares",
         "text": "Mas o que nós queremos é alargar o teste a milhões e a milhares.",
-        "time": 1548.455
+        "time": 1549.000
     },
     {
         "speaker": "Moderadora",
         "text": "Mariana Mortágua, quer só comentar essa questão? Porque de facto... Partilham esta medida da semana de quatro dias?",
-        "time": 1551.656
+        "time": 1549.500
     },
     {
         "speaker": "Mariana Mortágua",
@@ -1128,12 +1133,12 @@
     {
         "speaker": "Rui Tavares",
         "text": "É uma das coisas que as pessoas procuram.",
-        "time": 1563.000
+        "time": 1563.500
     },
     {
         "speaker": "Mariana Mortágua",
         "text": "É o que nós sabemos, eles procuram menos horas de trabalho.",
-        "time": 1564.562
+        "time": 1564.662
     },
     {
         "speaker": "Moderadora",
@@ -1148,7 +1153,7 @@
     {
         "speaker": "Moderadora",
         "text": "Não há falta de mão de obra, mesmo a administração pública que já tem tanta falta de pessoas?",
-        "time": 1571.000
+        "time": 1571.800
     },
     {
         "speaker": "Mariana Mortágua",
@@ -1193,12 +1198,12 @@
     {
         "speaker": "Moderadora",
         "text": "Fica essa consideração, Mariana. Estamos na reta final mesmo.",
-        "time": 1625.064
+        "time": 1623.500
     },
     {
         "speaker": "Moderadora",
-        "text": "Este tema — eu agora vou ter que começar com a Mariana para depois fecharmos o debate com o Rui Tavares.",
-        "time": 1626.785
+        "text": "Eu agora vou ter que começar com a Mariana para depois fecharmos o debate com o Rui Tavares.",
+        "time": 1627.000
     },
     {
         "speaker": "Moderadora",
@@ -1243,7 +1248,7 @@
     {
         "speaker": "Moderadora",
         "text": "Mas à luz que está a acontecer, não considera que a NATO ganhou uma nova relevância?",
-        "time": 1716.111
+        "time": 1715.500
     },
     {
         "speaker": "Mariana Mortágua",
@@ -1263,7 +1268,7 @@
     {
         "speaker": "Moderadora",
         "text": "Mas ainda assim, só para que fique claro, porque já estamos mesmo na reta final: o Bloco de Esquerda continua a defender a saída de Portugal da NATO?",
-        "time": 1735.55
+        "time": 1735.000
     },
     {
         "speaker": "Mariana Mortágua",
@@ -1283,7 +1288,7 @@
     {
         "speaker": "Moderadora",
         "text": "Estamos a ficar sem tempo, Rui, eu pedia-lhe que respondesse à minha pergunta.",
-        "time": 1769.000
+        "time": 1770.000
     },
     {
         "speaker": "Rui Tavares",
@@ -1323,7 +1328,7 @@
     {
         "speaker": "Mariana Mortágua",
         "text": "Isso é óbvio.",
-        "time": 1822.000
+        "time": 1823.000
     },
     {
         "speaker": "Rui Tavares",


### PR DESCRIPTION
Este PR é um follow-up do #9, onde deixei o seguinte comentário:

> Nota: algumas das entradas novas
> (que foram separadas de entradas existentes cuja identificação como diferentes oradores não tinha funcionado)
> têm timestamps interpolados manualmente e que podem não bater 100% certo com o áudio.

Ajustei alguns dos timestamps para baterem melhor com o timing do vídeo, e aproveitei para fazer mais umas correções adicionais que me tinham inicialmente escapado.
